### PR TITLE
Adds class to anchor tag

### DIFF
--- a/class.zoom-social-icons-widget.php
+++ b/class.zoom-social-icons-widget.php
@@ -129,7 +129,7 @@ class Zoom_Social_Icons_Widget extends WP_Widget {
 			<?php foreach ( $instance['fields'] as $field ) : ?>
 
 				<li class="zoom-social_icons-list__item">
-					<a href="<?php echo esc_url( $field['url'] ); ?>" <?php echo ( $instance['open-new-tab'] ? 'target="_blank"' : '' ); ?>>
+					<a class="zoom-social_icons-link" href="<?php echo esc_url( $field['url'] ); ?>" <?php echo ( $instance['open-new-tab'] ? 'target="_blank"' : '' ); ?>>
 						<span class="socicon socicon-<?php echo esc_attr( $this->get_icon( $field['url'] ) ); ?>"></span>
 
 						<?php if ( $instance['show-icon-labels'] ) : ?>


### PR DESCRIPTION
This small addition allows for easier styling of the zoom icons and distinction from css selectors such as `li a`.
